### PR TITLE
fix: correct UserPage import path

### DIFF
--- a/OneDrive/Documents/PROJECTS/WiFi Project Starlink v2/wifi-admin-panel/src/App.jsx
+++ b/OneDrive/Documents/PROJECTS/WiFi Project Starlink v2/wifi-admin-panel/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, createContext, useContext } from 'react';
 import { useAuth } from './hooks/useAuth';
 import AuthPage from './components/auth/AuthPage.jsx';
 import AdminPage from './pages/AdminPage.jsx';
-import UserPage from './pages/userPage.jsx';
+import UserPage from './pages/UserPage.jsx';
 import Spinner from './components/common/Spinner.jsx';
 import { auth } from './firebase';
 import Icon from './components/common/Icon.jsx';


### PR DESCRIPTION
## Summary
- fix incorrect casing in UserPage import so module resolves on case-sensitive systems

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689ff8d396d88329a9a466ba16ed6147